### PR TITLE
parallel process load

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/sqnc-process-management",
-  "version": "2.2.16",
+  "version": "2.2.17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/sqnc-process-management",
-      "version": "2.2.16",
+      "version": "2.2.17",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^10.12.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/sqnc-process-management",
-  "version": "2.2.16",
+  "version": "2.2.17",
   "description": "SQNC Process Management Flow",
   "main": "./lib/index.js",
   "bin": {

--- a/src/lib/process/api.ts
+++ b/src/lib/process/api.ts
@@ -19,40 +19,49 @@ export const createProcessTransaction = async (
   processId: Process.Hex,
   program: Process.Program,
   options: Polkadot.Options
-): Promise<Process.Payload> => {
+): Promise<{ waitForFinal: Promise<Process.Payload> }> => {
   const sudo = polkadot.keyring.addFromUri(options.USER_URI)
   const supportsManualSeal = !!polkadot.api.rpc.engine.createBlock
 
   if (!isProgramValid(program)) throw new ProgramError('invalid program')
 
-  return new Promise(async (resolve, reject) => {
-    try {
-      const unsub = await polkadot.api.tx.sudo
-        .sudo(polkadot.api.tx.processValidation.createProcess(processId, program))
-        .signAndSend(sudo, (result: any) => {
-          if (result.status.isFinalized) {
-            const { event } = result.events.find(
-              ({ event: { method } }: { event: { method: string } }) => method === 'ProcessCreated'
-            )
-
-            const data = event.data
-            const newProcess: Process.Payload = {
-              name: data[0].toHuman(),
-              version: data[1].toNumber(),
-              status: 'Enabled',
-              program,
-            }
-            unsub()
-            resolve(newProcess)
-          }
-        })
-      if (supportsManualSeal) {
-        await polkadot.api.rpc.engine.createBlock(true, true)
-      }
-    } catch (err) {
-      reject(err)
-    }
+  let resolve: (value: Process.Payload) => void = () => {}
+  let reject: (reason: any) => void = () => {}
+  const result: Promise<Process.Payload> = new Promise((res, rej) => {
+    resolve = res
+    reject = rej
   })
+
+  try {
+    const unsub = await polkadot.api.tx.sudo
+      .sudo(polkadot.api.tx.processValidation.createProcess(processId, program))
+      .signAndSend(sudo, (result: any) => {
+        if (result.status.isFinalized) {
+          const { event } = result.events.find(
+            ({ event: { method } }: { event: { method: string } }) => method === 'ProcessCreated'
+          )
+
+          const data = event.data
+          const newProcess: Process.Payload = {
+            name: data[0].toHuman(),
+            version: data[1].toNumber(),
+            status: 'Enabled',
+            program,
+          }
+          unsub()
+          resolve(newProcess)
+        }
+      })
+    if (supportsManualSeal) {
+      await polkadot.api.rpc.engine.createBlock(true, true)
+    }
+  } catch (err) {
+    reject(err)
+  }
+
+  return {
+    waitForFinal: result,
+  }
 }
 
 export const disableProcessTransaction = async (

--- a/src/lib/process/api.ts
+++ b/src/lib/process/api.ts
@@ -35,7 +35,7 @@ export const createProcessTransaction = async (
   try {
     const unsub = await polkadot.api.tx.sudo
       .sudo(polkadot.api.tx.processValidation.createProcess(processId, program))
-      .signAndSend(sudo, (result: any) => {
+      .signAndSend(sudo, { nonce: -1 }, (result: any) => {
         if (result.status.isFinalized) {
           const { event } = result.events.find(
             ({ event: { method } }: { event: { method: string } }) => method === 'ProcessCreated'

--- a/src/lib/process/index.ts
+++ b/src/lib/process/index.ts
@@ -85,7 +85,7 @@ export const loadProcesses = async ({
     }
   }
 
-  // calculate the result and successCOunt
+  // calculate the result and successCount
 
   return {
     type: 'ok',
@@ -140,7 +140,7 @@ export const createProcess = async (
 }> => {
   const handleErr = (err: unknown) => {
     // err is basically from errors.ts or any exception
-    // process errors will comntain specific messages and/or process
+    // process errors will contain specific messages and/or process
     // Promise<Process.Result> is in try {} and any exception is in catch {}
     if (err instanceof ProgramError || err instanceof VersionError || err instanceof ZodError) {
       const result: Process.ProcessResponse = {

--- a/src/lib/process/index.ts
+++ b/src/lib/process/index.ts
@@ -68,16 +68,24 @@ export const loadProcesses = async ({
   }
   const processes = parsedRes.result
 
-  const [result, successCount] = await processes.reduce<Promise<[{ [key: string]: Process.ProcessResponse }, number]>>(
-    async (acc, process) => {
-      const [result, oldCount] = await acc
-      const processResult = await createProcess(process, dryRun, options, verbose)
-      const newCount = processResult.type === 'ok' ? oldCount + 1 : oldCount
-      result[process.name] = processResult
-      return [result, newCount]
-    },
-    Promise.resolve([{}, 0])
-  )
+  const processTxs: Map<string, Promise<Process.ProcessResponse>> = new Map()
+  for (const process of processes) {
+    const { waitForFinalised } = await createProcess(process, dryRun, options, verbose)
+    processTxs.set(process.name, waitForFinalised)
+  }
+  await Promise.all(processTxs.values())
+
+  const result: { [key: string]: Process.ProcessResponse } = {}
+  let successCount = 0
+  for (const [key, processTxProm] of processTxs) {
+    let response = await processTxProm
+    result[key] = response
+    if (response.type === 'ok') {
+      successCount = successCount + 1
+    }
+  }
+
+  // calculate the result and successCOunt
 
   return {
     type: 'ok',
@@ -127,7 +135,35 @@ export const createProcess = async (
   dryRun: boolean = false,
   options: Polkadot.Options = defaultOptions,
   verbose: boolean = false
-): Promise<Process.ProcessResponse> => {
+): Promise<{
+  waitForFinalised: Promise<Process.ProcessResponse>
+}> => {
+  const handleErr = (err: unknown) => {
+    // err is basically from errors.ts or any exception
+    // process errors will comntain specific messages and/or process
+    // Promise<Process.Result> is in try {} and any exception is in catch {}
+    if (err instanceof ProgramError || err instanceof VersionError || err instanceof ZodError) {
+      const result: Process.ProcessResponse = {
+        type: 'error' as 'error',
+        error: err,
+        message: err.message,
+      }
+      return {
+        waitForFinalised: Promise.resolve(result),
+      }
+    } else if (err instanceof Error) {
+      const result: Process.ProcessResponse = {
+        type: 'error' as 'error',
+        error: err,
+        message: 'An unknown error occurred',
+      }
+      return {
+        waitForFinalised: Promise.resolve(result),
+      }
+    }
+    throw err
+  }
+
   try {
     const { name, version, program } = processValidation.parse(processRaw)
 
@@ -148,58 +184,54 @@ export const createProcess = async (
         throw new ProgramError('existing: program steps did not match', process)
 
       return {
-        type: 'ok',
-        message: `Skipping: process ${name} is already created.`,
-        result: handleVerbose(
-          {
-            name,
-            version,
-            program,
-            status: process.status,
-          },
-          verbose
-        ),
+        waitForFinalised: Promise.resolve({
+          type: 'ok',
+          message: `Skipping: process ${name} is already created.`,
+          result: handleVerbose(
+            {
+              name,
+              version,
+              program,
+              status: process.status,
+            },
+            verbose
+          ),
+        }),
       }
     }
 
     if (dryRun)
       return {
-        type: 'ok',
-        message: 'Dry run: transaction has not been created',
-        result: handleVerbose(
-          {
-            name,
-            version,
-            program,
-            status: 'Enabled (dry-run)',
-          },
-          verbose
-        ),
+        waitForFinalised: Promise.resolve({
+          type: 'ok',
+          message: 'Dry run: transaction has not been created',
+          result: handleVerbose(
+            {
+              name,
+              version,
+              program,
+              status: 'Enabled (dry-run)',
+            },
+            verbose
+          ),
+        }),
       }
 
+    const createProcessTx = await createProcessTransaction(polkadot, processId, program, options)
     return {
-      type: 'ok',
-      message: `Transaction for new process ${name} has been successfully submitted`,
-      result: handleVerbose(await createProcessTransaction(polkadot, processId, program, options), verbose),
+      waitForFinalised: createProcessTx.waitForFinal
+        .then((process) => {
+          const result: Process.ProcessResponse = {
+            type: 'ok',
+            message: `Transaction for new process ${name} has been successfully submitted`,
+            result: handleVerbose(process, verbose),
+          }
+          return result
+        })
+        .catch((err) => handleErr(err).waitForFinalised),
     }
   } catch (err) {
-    // err is basically from errors.ts or any exception
-    // process errors will comntain specific messages and/or process
-    // Promise<Process.Result> is in try {} and any exception is in catch {}
-    if (err instanceof ProgramError || err instanceof VersionError || err instanceof ZodError) {
-      return {
-        type: 'error',
-        error: err,
-        message: err.message,
-      }
-    } else if (err instanceof Error) {
-      return {
-        type: 'error',
-        error: err,
-        message: 'An unknown error occurred',
-      }
-    }
-    throw err
+    return handleErr(err)
   }
 }
 


### PR DESCRIPTION
This PR updates how `loadProcesses` works to enable parallel loading of processes. In short I modify `createProcess` to now return an object that encapsulates a Promise that will only resolve when the transaction is finalised. The Promise returned be `createProcess` resolves now instead when the transaction has been loaded into the transaction pool.

Note there's quite a lot of complexity in the change to `loadProcesses` as we have to serially await the transaction submission part but parralel load (with `Promise.all`) the wait for completion. Finally note the `{ none: -1 }` on submission to use latest nonce.

I have tested this on the L3 flows and it works perfectly although I have noticed the readme seems out of date. I copied the `processFlows.json` to`./l3.json` from `dscp-matchmaker-api`, brought up the non-test docker compose and then ran

```
npm run build
./build/src/index.js create -f l3.json -u //Alice
```