### PR TITLE
Fix github npm package release permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
       npm_build: true
     permissions:
       contents: write
+      packages: write
     secrets:
       REGISTRY_AUTH_TOKEN: ${{ secrets.NPMJS_TOKEN }}
   release-gh-packages:
@@ -33,8 +34,7 @@ jobs:
       registry_url: 'https://npm.pkg.github.com'
     permissions:
       contents: write
-    secrets:
-      REGISTRY_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      packages: write
   release-github:
     needs: [release-npm, release-gh-packages]
     uses: digicatapult/shared-workflows/.github/workflows/release-github.yml@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
     needs: [static-checks-npm, tests-npm]
     uses: digicatapult/shared-workflows/.github/workflows/release-module-npm.yml@main
     with:
-      npm_build: true
+      npm_build_command: npm run build
     permissions:
       contents: write
       packages: write
@@ -30,7 +30,7 @@ jobs:
     needs: [static-checks-npm, tests-npm]
     uses: digicatapult/shared-workflows/.github/workflows/release-module-npm.yml@main
     with:
-      npm_build: true
+      npm_build_command: npm run build
       registry_url: 'https://npm.pkg.github.com'
     permissions:
       contents: write


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [x] Bug Fix
- [ ] Chore
- [ ] Feature
- [ ] Documentation Update
- [ ] Code style update (formatting, local variables)
- [ ] Breaking Change (fix or feature that would cause existing functionality to change)

## Linked tickets

https://digicatapult.atlassian.net/browse/SQNC-50

## High level description

Fixes a bug in the release of github npm package due to permissions

## Detailed description

This PR depends on https://github.com/digicatapult/shared-workflows/pull/18 which adds support for publishing a github npm package using the `GITHUB_TOKEN` secret.

Note the lack of version bump as the previous release failed

## Describe alternatives you've considered

None

## Operational impact

See https://github.com/digicatapult/shared-workflows/pull/18 for steps to revert

## Additional context

https://github.com/digicatapult/shared-workflows/pull/18
