### PR TITLE
Only support version 22 of node

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/sqnc-process-management",
-  "version": "2.2.157",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/sqnc-process-management",
-      "version": "2.2.157",
+      "version": "3.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^15.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/sqnc-process-management",
-  "version": "2.2.156",
+  "version": "2.2.157",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/sqnc-process-management",
-      "version": "2.2.156",
+      "version": "2.2.157",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^15.1.1",
@@ -41,8 +41,8 @@
         "testcontainers": "^10.16.0"
       },
       "engines": {
-        "node": ">=22.x.x",
-        "npm": ">=10.x.x"
+        "node": "^22.x.x",
+        "npm": "^10.x.x"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/sqnc-process-management",
-  "version": "2.2.157",
+  "version": "3.0.0",
   "description": "SQNC Process Management Flow",
   "main": "./lib/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/sqnc-process-management",
-  "version": "2.2.156",
+  "version": "2.2.157",
   "description": "SQNC Process Management Flow",
   "main": "./lib/index.js",
   "bin": {
@@ -27,8 +27,8 @@
     "/build"
   ],
   "engines": {
-    "node": ">=22.x.x",
-    "npm": ">=10.x.x"
+    "node": "^22.x.x",
+    "npm": "^10.x.x"
   },
   "author": "Digital Catapult",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [ ] Bug Fix
- [x] Chore
- [ ] Feature
- [ ] Documentation Update
- [ ] Code style update (formatting, local variables)
- [ ] Breaking Change (fix or feature that would cause existing functionality to change)

## Linked tickets

https://digicatapult.atlassian.net/browse/SQNC-44

## High level description

Sets supported node version to 22 and supported npm to 10

## Detailed description

Whilst we were always running on latest lts we previously advertised support for node 22 or higher. We're restricting that now. Technically this is a major bump as it previously advertised support for node above 22 e.g. 23

As a final note the last release failed due to a version overwriting issue in npm that we can't fix. This will publish a new version that will fix all that

## Describe alternatives you've considered

N/A

## Operational impact

None

## Additional context

N/A
